### PR TITLE
Extract in a method the remote IP extraction

### DIFF
--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -20,7 +20,7 @@ module Devise
         self.last_sign_in_at     = old_current || new_current
         self.current_sign_in_at  = new_current
 
-        old_current, new_current = self.current_sign_in_ip, request.remote_ip
+        old_current, new_current = self.current_sign_in_ip, extract_ip_from(request)
         self.last_sign_in_ip     = old_current || new_current
         self.current_sign_in_ip  = new_current
 
@@ -32,6 +32,13 @@ module Devise
         update_tracked_fields(request)
         save(validate: false)
       end
+
+      protected
+
+      def extract_ip_from(request)
+        request.remote_ip
+      end
+
     end
   end
 end


### PR DESCRIPTION
Extracting the implementation to be able to override the way how to get the remote IP from the client.